### PR TITLE
Use Invention Assets for the tile files

### DIFF
--- a/InventionUiWpf/InventionUiWpf.csproj
+++ b/InventionUiWpf/InventionUiWpf.csproj
@@ -10,6 +10,15 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+	  <Content Include="..\absurd64.bmp" Link="Assets\absurd64.bmp">
+	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </Content>
+	  <Content Include="..\tiledata.json" Link="Assets\tiledata.json">
+	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </Content>
+	</ItemGroup>
+
+	<ItemGroup>
 		<Reference Include="Inv.Library">
 		  <HintPath>..\lib\Inv.Library.dll</HintPath>
 		</Reference>
@@ -30,6 +39,10 @@
 	<ItemGroup>
 		<ProjectReference Include="..\Portable\Portable.csproj" />
 		<ProjectReference Include="..\Engine\Engine.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <Folder Include="Assets\" />
 	</ItemGroup>
 
 </Project>

--- a/Portable/MegaDungeonUI.cs
+++ b/Portable/MegaDungeonUI.cs
@@ -44,7 +44,9 @@ namespace Portable
 			_horizontalCellCount = horizontalCellCount;
 			_verticalCellCount = verticalCellCount;
 
-			_tileManager = new TileManager("absurd64.bmp", System.IO.File.ReadAllText("tiledata.json"));
+			var directory = surface.Window.Application.Directory;
+
+			_tileManager = new TileManager(directory.NewAsset("absurd64.bmp"), directory.NewAsset("tiledata.json"));
 			_engine = new MegaDungeon.Engine(horizontalCellCount, verticalCellCount, _tileManager);
 
 			_surface = surface;

--- a/Portable/TileManager.cs
+++ b/Portable/TileManager.cs
@@ -21,10 +21,11 @@ namespace Portable
 		Dictionary<int, Inv.Image> _tileCache = new Dictionary<int, Inv.Image>();
 		Dictionary<int, Inv.Image> _darkTileCache = new Dictionary<int, Inv.Image>();
 
-		public TileManager(string tileImageFile, string tileDataJson)
+		public TileManager(Inv.Asset tileImageFile, Inv.Asset tileDataJson)
 		{
-			_tileset = Image.Load(tileImageFile);
-			_tileData = JsonConvert.DeserializeObject<TileData>(tileDataJson);
+			using (var tileStream = tileImageFile.Open())
+				_tileset = Image.Load(tileStream);
+			_tileData = JsonConvert.DeserializeObject<TileData>(tileDataJson.AsText().ReadAll());
 			_tileSize = _tileData.tile_size;
 		}
 


### PR DESCRIPTION
This is a necessary step for introducing the Xamarin iOS and Android projects. The loose tile files need to be copied with the built application.